### PR TITLE
fix: multiply H by eta in manifold_muon

### DIFF
--- a/src/manifold_muon.py
+++ b/src/manifold_muon.py
@@ -16,7 +16,7 @@ def manifold_muon(W, G, eta=0.1, alpha=0.01, steps=100, tol=1e-6):
         # Update the candidate direction A
         A = msign(G + 2 * W @ Lambda)
         # Measure deviation of A from the tangent space:
-        H = W.T @ A + A.T @ W
+        H = eta * (W.T @ A + A.T @ W)
         # Check the stopping criterion
         if torch.norm(H) / math.sqrt(H.numel()) < tol:
             break


### PR DESCRIPTION
Good day,

I noticed that in issue #1, there was a comment about the code forgetting the multiplication with eta when assembling H.

This PR fixes the issue by properly multiplying H by eta in the manifold_muon function, ensuring the tangent constraint metric is correctly scaled by the learning rate.

## Changes
- src/manifold_muon.py: Changed "H = W.T @ A + A.T @ W" to "H = eta * (W.T @ A + A.T @ W)"

This addresses the concern raised in issue #1 about the missing eta multiplication in the H calculation.

Thank you for your work on this excellent library!

Warmly,
RoomWithOutRoof